### PR TITLE
README: update for new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This problem matcher lets you show errors from `xmllint` as annotation in GitHub
 Add the step to your workflow, before `xmllint` is called.
 
 ```yaml
-    - uses: korelstar/xmllint-problem-matcher@v1
+    - uses: korelstar/xmllint-problem-matcher@v1.1
 ```


### PR DESCRIPTION
Looks like this action runner is not using "long-running branches", which means that to use the latest version of this action runner, the usage instructions need to be updated.

Alternatively, please consider having a `v1` tag which moves on every release within the `1.x` range or have a `v1` branch for the whole `1.x` development cycle.
This would mean that people would automatically get the latest version and don't have to update their workflows.